### PR TITLE
Default to a sensible place for the config

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ pysmb = "*"
 keyring = "*"
 pyyaml = "*"
 stevedore = "*"
+appdirs = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8120df5c2657dc18108be923a330747b6aa688d276606abc5d09aeca54bcb075"
+            "sha256": "7cf5a84b10bb698531a0ca3e0d60549ceb66c70c4411a32901e33aa82e2f1af4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "index": "pypi",
+            "version": "==1.4.3"
+        },
         "asn1crypto": {
             "hashes": [
                 "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
@@ -224,7 +232,7 @@
                 "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
                 "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
             ],
-            "markers": "python_version == '2.7'",
+            "markers": "python_version < '3.4'",
             "version": "==1.5"
         },
         "colorama": {

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -16,6 +16,7 @@ Why does this file exist, and why not put this in __main__?
 """
 
 import pathlib
+import typing
 
 import click
 
@@ -29,10 +30,10 @@ def cli() -> None:
 
 
 @cli.command()
-@click.argument('config_file', type=pathlib.Path)
-def sync(config_file: pathlib.Path) -> None:
+@click.option('--config', type=pathlib.Path, help="The configuration file to use")
+def sync(config: typing.Optional[pathlib.Path] = None) -> None:
     """Synchronize with the given configuration file."""
     try:
-        syncing.start_all(config_file)
+        syncing.start_all(config)
     except utils.UsageError as ex:
         raise click.ClickException(str(ex))

--- a/src/kitovu/sync/settings.py
+++ b/src/kitovu/sync/settings.py
@@ -4,6 +4,7 @@ import pathlib
 import typing
 import os.path
 
+import appdirs
 import yaml
 import attr
 
@@ -31,8 +32,10 @@ class Settings:
     connections: typing.Dict[str, ConnectionSettings] = attr.ib()
 
     @classmethod
-    def from_yaml_file(cls, path: pathlib.Path) -> 'Settings':
+    def from_yaml_file(cls, path: typing.Optional[pathlib.Path] = None) -> 'Settings':
         """Load the settings from the specified yaml file"""
+        if path is None:
+            path = get_config_file_path()
         with path.open('r') as stream:
             return cls.from_yaml_stream(stream)
 
@@ -94,3 +97,11 @@ class Settings:
         """Raise an error if the specified dictionary is not empty."""
         if data:
             raise utils.UnknownSettingKeysError(list(data.keys()))
+
+
+def get_config_dir_path() -> pathlib.Path:
+    return pathlib.Path(appdirs.user_config_dir('kitovu'))
+
+
+def get_config_file_path() -> pathlib.Path:
+    return get_config_dir_path() / 'kitovu.yaml'

--- a/src/kitovu/sync/syncing.py
+++ b/src/kitovu/sync/syncing.py
@@ -1,6 +1,7 @@
 """Logic related to actually syncing files."""
 
 import pathlib
+import typing
 
 import stevedore
 import stevedore.driver
@@ -29,7 +30,7 @@ def _find_plugin(pluginname: str) -> syncplugin.AbstractSyncPlugin:
     return plugin
 
 
-def start_all(config_file: pathlib.Path) -> None:
+def start_all(config_file: typing.Optional[pathlib.Path]) -> None:
     """Sync all files with the given configuration file."""
     settings = Settings.from_yaml_file(config_file)
     for _plugin_key, connection_settings in sorted(settings.connections.items()):


### PR DESCRIPTION
Part of EPJ-73

If no config is given, something like `~/.config/kitovu/kitovu.yaml` (on Linux) is used. No quickstart stuff implemented yet.