### PR TITLE
added reporters for printing warnings

### DIFF
--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -24,6 +24,11 @@ from kitovu import utils
 from kitovu.sync import syncing
 
 
+class CliReporter(utils.AbstractReporter):
+    def warning(self, message: str) -> None:
+        print(message)
+
+
 @click.group()
 def cli() -> None:
     pass
@@ -34,6 +39,6 @@ def cli() -> None:
 def sync(config: typing.Optional[pathlib.Path] = None) -> None:
     """Synchronize with the given configuration file."""
     try:
-        syncing.start_all(config)
+        syncing.start_all(config, CliReporter())
     except utils.UsageError as ex:
         raise click.ClickException(str(ex))

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -25,6 +25,8 @@ from kitovu.sync import syncing
 
 
 class CliReporter(utils.AbstractReporter):
+    """A reporter for printing to the console."""
+
     def warn(self, message: str) -> None:
         print(message)
 

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -17,6 +17,7 @@ Why does this file exist, and why not put this in __main__?
 
 import pathlib
 import typing
+import sys
 
 import click
 
@@ -28,7 +29,7 @@ class CliReporter(utils.AbstractReporter):
     """A reporter for printing to the console."""
 
     def warn(self, message: str) -> None:
-        print(message)
+        print(message, file=sys.stderr)
 
 
 @click.group()

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -25,7 +25,7 @@ from kitovu.sync import syncing
 
 
 class CliReporter(utils.AbstractReporter):
-    def warning(self, message: str) -> None:
+    def warn(self, message: str) -> None:
         print(message)
 
 

--- a/src/kitovu/sync/plugin/smb.py
+++ b/src/kitovu/sync/plugin/smb.py
@@ -41,7 +41,8 @@ class SmbPlugin(syncplugin.AbstractSyncPlugin):
 
     """A plugin to sync data via SMB/CIFS (Windows fileshares)."""
 
-    def __init__(self) -> None:
+    def __init__(self, reporter: utils.AbstractReporter) -> None:
+        super().__init__(reporter)
         self._connection: SMBConnection = None
         self._info = _ConnectionInfo()
 

--- a/src/kitovu/sync/syncing.py
+++ b/src/kitovu/sync/syncing.py
@@ -30,16 +30,17 @@ def _find_plugin(pluginname: str) -> syncplugin.AbstractSyncPlugin:
     return plugin
 
 
-def start_all(config_file: typing.Optional[pathlib.Path]) -> None:
+def start_all(config_file: typing.Optional[pathlib.Path], reporter: utils.AbstractReporter) -> None:
     """Sync all files with the given configuration file."""
     settings = Settings.from_yaml_file(config_file)
     for _plugin_key, connection_settings in sorted(settings.connections.items()):
-        start(connection_settings)
+        start(connection_settings, reporter)
 
 
-def start(connection_settings: ConnectionSettings) -> None:
+def start(connection_settings: ConnectionSettings, reporter: utils.AbstractReporter) -> None:
     """Sync files with the given plugin and username."""
     plugin = _find_plugin(connection_settings.plugin_name)
+    plugin.reporter = reporter
     plugin.configure(connection_settings.connection)
     plugin.connect()
 

--- a/src/kitovu/sync/syncing.py
+++ b/src/kitovu/sync/syncing.py
@@ -24,7 +24,7 @@ def _find_plugin(pluginname: str,
     try:
         manager = stevedore.driver.DriverManager(namespace='kitovu.sync.plugin',
                                                  name=pluginname, invoke_on_load=True,
-                                                 invoke_args=(reporter))
+                                                 invoke_args=(reporter,))
     except stevedore.exception.NoMatches:
         raise utils.NoPluginError(f"The plugin {pluginname} was not found")
 

--- a/src/kitovu/sync/syncplugin.py
+++ b/src/kitovu/sync/syncplugin.py
@@ -14,7 +14,8 @@ class AbstractSyncPlugin(metaclass=abc.ABCMeta):
     Every abstract method in this class is a plugin hook.
     """
 
-    reporter: utils.AbstractReporter
+    def __init__(self, reporter: utils.AbstractReporter) -> None:
+        self.reporter: utils.AbstractReporter = reporter
 
     @abc.abstractmethod
     def configure(self, info: typing.Dict[str, typing.Any]) -> None:

--- a/src/kitovu/sync/syncplugin.py
+++ b/src/kitovu/sync/syncplugin.py
@@ -4,6 +4,8 @@ import abc
 import pathlib
 import typing
 
+from kitovu import utils
+
 
 class AbstractSyncPlugin(metaclass=abc.ABCMeta):
 
@@ -11,6 +13,8 @@ class AbstractSyncPlugin(metaclass=abc.ABCMeta):
 
     Every abstract method in this class is a plugin hook.
     """
+
+    reporter: utils.AbstractReporter
 
     @abc.abstractmethod
     def configure(self, info: typing.Dict[str, typing.Any]) -> None:

--- a/src/kitovu/utils.py
+++ b/src/kitovu/utils.py
@@ -76,6 +76,6 @@ class UnknownSettingKeysError(InvalidSettingsError):
 class AbstractReporter(metaclass=abc.ABCMeta):
     """A class that handles the reporting of warnings to the UI or CLI."""
     @abc.abstractmethod
-    def warning(self, message: str) -> None:
+    def warn(self, message: str) -> None:
         """Print the warning according to the current interface."""
         raise NotImplementedError

--- a/src/kitovu/utils.py
+++ b/src/kitovu/utils.py
@@ -2,6 +2,7 @@
 
 import typing
 import getpass
+import abc
 
 import keyring
 
@@ -70,3 +71,11 @@ class UnknownSettingKeysError(InvalidSettingsError):
 
         keys = ', '.join(self.unknown_keys)
         super().__init__(f'Unknown keys: {keys}')
+
+
+class AbstractReporter(metaclass=abc.ABCMeta):
+    """A class that handles the reporting of warnings to the UI or CLI."""
+    @abc.abstractmethod
+    def warning(self, message: str) -> None:
+        """Print the warning according to the current interface."""
+        raise NotImplementedError

--- a/tests/helpers/dummyplugin.py
+++ b/tests/helpers/dummyplugin.py
@@ -6,6 +6,8 @@ import typing
 import attr
 
 from kitovu.sync import syncplugin
+from kitovu import utils
+from helpers import reporter
 
 
 @attr.s
@@ -18,9 +20,10 @@ class Digests:
 class DummyPlugin(syncplugin.AbstractSyncPlugin):
 
     def __init__(self,
+                 reporter: utils.AbstractReporter=reporter.TestReporter(),
                  local_digests: typing.Dict[pathlib.PurePath, str]=None,
                  remote_digests: typing.Dict[pathlib.PurePath, str]=None):
-        super().__init__()
+        super().__init__(reporter)
         self.local_digests = local_digests if local_digests else {
             pathlib.PurePath("local_dir/test/example1.txt"): "1",
             pathlib.PurePath("local_dir/test/example2.txt"): "2",

--- a/tests/helpers/reporter.py
+++ b/tests/helpers/reporter.py
@@ -2,7 +2,7 @@ from kitovu.utils import AbstractReporter
 
 
 class TestReporter(AbstractReporter):
-    def __init__(self, raise_errors=False):
+    def __init__(self, raise_errors=True):
         self.raise_errors = raise_errors
         self.messages = []
 

--- a/tests/helpers/reporter.py
+++ b/tests/helpers/reporter.py
@@ -1,0 +1,10 @@
+from kitovu.utils import AbstractReporter
+
+
+class TestReporter(AbstractReporter):
+    def __init__(self, raise_errors=False):
+        self.raise_errors = raise_errors
+
+    def warning(self, message):
+        if self.raise_errors:
+            raise Exception(message)

--- a/tests/helpers/reporter.py
+++ b/tests/helpers/reporter.py
@@ -4,7 +4,10 @@ from kitovu.utils import AbstractReporter
 class TestReporter(AbstractReporter):
     def __init__(self, raise_errors=False):
         self.raise_errors = raise_errors
+        self.messages = []
 
     def warn(self, message):
         if self.raise_errors:
             raise Exception(message)
+        else:
+            self.messages.append(message)

--- a/tests/helpers/reporter.py
+++ b/tests/helpers/reporter.py
@@ -5,6 +5,6 @@ class TestReporter(AbstractReporter):
     def __init__(self, raise_errors=False):
         self.raise_errors = raise_errors
 
-    def warning(self, message):
+    def warn(self, message):
         if self.raise_errors:
             raise Exception(message)

--- a/tests/sync/test_smb.py
+++ b/tests/sync/test_smb.py
@@ -6,6 +6,7 @@ import keyring
 from smb.SMBConnection import SMBConnection
 
 from kitovu.sync.plugin import smb
+from helpers import reporter
 
 
 @pytest.fixture(autouse=True)
@@ -67,7 +68,7 @@ class TestConnect:
 
     @pytest.fixture
     def plugin(self):
-        return smb.SmbPlugin()
+        return smb.SmbPlugin(reporter.TestReporter())
 
     @pytest.fixture
     def info(self):
@@ -142,7 +143,7 @@ class TestWithConnectedPlugin:
 
     @pytest.fixture
     def plugin(self):
-        plugin = smb.SmbPlugin()
+        plugin = smb.SmbPlugin(reporter.TestReporter())
         keyring.set_password('kitovu-smb', 'myusername\nHSR\nsvm-c213.hsr.ch', 'some_password')
         plugin.configure({'username': 'myusername'})
         plugin.connect()

--- a/tests/sync/test_syncing.py
+++ b/tests/sync/test_syncing.py
@@ -7,7 +7,7 @@ import stevedore
 from kitovu import utils
 from kitovu.sync import syncing
 from kitovu.sync.plugin import smb
-from helpers import dummyplugin
+from helpers import dummyplugin, reporter
 
 
 class TestFindPlugin:
@@ -76,7 +76,7 @@ class TestSyncAll:
                   - connection: another-plugin
                     remote-dir: Another/Test/Dir2
             """)
-        syncing.start_all(file_name)
+        syncing.start_all(file_name, reporter.TestReporter())
 
         assert sorted(pathlib.Path(tmpdir).glob("syncs/**/*")) == [
             pathlib.Path(f'{tmpdir}/syncs/sync-1'),

--- a/tests/sync/test_syncing.py
+++ b/tests/sync/test_syncing.py
@@ -13,7 +13,7 @@ from helpers import dummyplugin, reporter
 class TestFindPlugin:
 
     def test_find_plugin_builtin(self):
-        plugin = syncing._find_plugin('smb')
+        plugin = syncing._find_plugin('smb', reporter.TestReporter())
         assert isinstance(plugin, smb.SmbPlugin)
 
     def test_find_plugin_missing_external(self, mocker):
@@ -21,7 +21,7 @@ class TestFindPlugin:
                      side_effect=stevedore.exception.NoMatches)
 
         with pytest.raises(utils.NoPluginError, match='The plugin doesnotexist was not found'):
-            syncing._find_plugin('doesnotexist')
+            syncing._find_plugin('doesnotexist', reporter.TestReporter())
 
     def test_find_plugin_external(self, mocker):
         fake_plugin_obj = object()
@@ -30,7 +30,7 @@ class TestFindPlugin:
                            invoke_on_load=True)
         instance.driver = fake_plugin_obj
 
-        plugin = syncing._find_plugin('test')
+        plugin = syncing._find_plugin('test', reporter.TestReporter())
         assert plugin is fake_plugin_obj
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,5 +13,5 @@ def test_reporter(capsys, reporter):
     reporter.warn("another test")
 
     captured = capsys.readouterr()
-    assert captured.out == "my test\nanother test\n"
-    assert captured.err == ""
+    assert captured.out == ""
+    assert captured.err == "my test\nanother test\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+import pytest
+
+from kitovu.cli import CliReporter
+
+
+@pytest.fixture
+def reporter():
+    return CliReporter()
+
+
+def test_reporter(capsys, reporter):
+    reporter.warn("my test")
+    reporter.warn("another test")
+
+    captured = capsys.readouterr()
+    assert captured.out == "my test\nanother test\n"
+    assert captured.err == ""

--- a/tests/test_test_reporter.py
+++ b/tests/test_test_reporter.py
@@ -1,0 +1,36 @@
+import pytest
+
+import helpers.reporter
+
+
+def test_reporter_with_defaults():
+    reporter = helpers.reporter.TestReporter()
+    reporter.warn("test 1")
+    reporter.warn("test 2")
+
+    assert reporter.messages == [
+        "test 1",
+        "test 2",
+    ]
+
+
+def test_reporter_without_raising():
+    reporter = helpers.reporter.TestReporter(raise_errors=False)
+    reporter.warn("my test")
+    reporter.warn("another test")
+
+    assert reporter.messages == [
+        "my test",
+        "another test",
+    ]
+
+
+def test_reporter_with_raising():
+    reporter = helpers.reporter.TestReporter(raise_errors=True)
+    with pytest.raises(Exception) as excinfo:
+        reporter.warn("my test")
+    assert str(excinfo.value) == "my test"
+
+    with pytest.raises(Exception) as excinfo:
+        reporter.warn("another test")
+    assert str(excinfo.value) == "another test"

--- a/tests/test_test_reporter.py
+++ b/tests/test_test_reporter.py
@@ -4,14 +4,14 @@ import helpers.reporter
 
 
 def test_reporter_with_defaults():
-    reporter = helpers.reporter.TestReporter()
-    reporter.warn("test 1")
-    reporter.warn("test 2")
+    reporter = helpers.reporter.TestReporter(raise_errors=True)
+    with pytest.raises(Exception) as excinfo:
+        reporter.warn("my test")
+    assert str(excinfo.value) == "my test"
 
-    assert reporter.messages == [
-        "test 1",
-        "test 2",
-    ]
+    with pytest.raises(Exception) as excinfo:
+        reporter.warn("another test")
+    assert str(excinfo.value) == "another test"
 
 
 def test_reporter_without_raising():


### PR DESCRIPTION
The reporter is used for printing warnings, either directly (in the CLI) or maybe only at the end (in the UI)

Usage in the pluigins: `self.reporter.warn("my message")`