### PR TITLE
Feature add docs and edit cli commands

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,3 +25,6 @@ max-attributes = 10
 # _CountingAttr: Needed for attrs
 # pathlib.PurePath: Detected when we actually have a pathlib.Path
 ignored-classes=_CountingAttr,pathlib.PurePath
+
+# distutils: See issue https://github.com/PyCQA/pylint/issues/73
+ignored-modules=distutils

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -86,8 +86,8 @@ DEFAULT_EDITORS = [
 
 @cli.command()
 @click.option('--config', type=pathlib.Path, help="The configuration file to edit")
-@click.option('--editor', type=str, help=f"The command of the editor to use. \
-              Default: $EDITOR or the first existing out of {', '.join(DEFAULT_EDITORS)}")
+@click.option('--editor', type=str, help="The command of the editor to use. "
+              f"Default: $EDITOR or the first existing out of {', '.join(DEFAULT_EDITORS)}")
 def edit(config: typing.Optional[pathlib.Path] = None, editor: typing.Optional[str] = None) -> None:
     """Edit the specified configuration file."""
     if editor is None and 'EDITOR' in os.environ:

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -18,7 +18,6 @@ Why does this file exist, and why not put this in __main__?
 import pathlib
 import typing
 import sys
-import platform
 from distutils import spawn
 import subprocess
 import os
@@ -76,7 +75,7 @@ def docs() -> None:
     webbrowser.open_new_tab('https://kitovu.readthedocs.io/en/latest')
 
 
-AVAILABLE_EDITORS = [
+DEFAULT_EDITORS = [
     'vim',
     'emacs',
     'nano',
@@ -87,7 +86,8 @@ AVAILABLE_EDITORS = [
 
 @cli.command()
 @click.option('--config', type=pathlib.Path, help="The configuration file to edit")
-@click.option('--editor', type=str, help=f"The command of the editor to use. Default: $EDITOR or the first existing out of {', '.join(AVAILABLE_EDITORS)}")
+@click.option('--editor', type=str, help=f"The command of the editor to use. \
+              Default: $EDITOR or the first existing out of {', '.join(DEFAULT_EDITORS)}")
 def edit(config: typing.Optional[pathlib.Path] = None, editor: typing.Optional[str] = None) -> None:
     """Edit the specified configuration file."""
     if editor is None and 'EDITOR' in os.environ:
@@ -108,8 +108,8 @@ def _get_editor_path(editor: typing.Optional[str]) -> typing.Optional[str]:
     if editor is not None:
         return spawn.find_executable(editor)
 
-    for e in AVAILABLE_EDITORS:
-        path = spawn.find_executable(e)
+    for default_editor in DEFAULT_EDITORS:
+        path = spawn.find_executable(default_editor)
         if path is not None:
             return path
 

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -92,25 +92,21 @@ def edit(config: typing.Optional[pathlib.Path] = None, editor: typing.Optional[s
     """Edit the specified configuration file."""
     if editor is None and 'EDITOR' in os.environ:
         editor = os.environ['EDITOR']
-    editor_path: typing.Optional[str] = _get_editor_path(editor)
-
-    if editor_path is None:
-        if editor is None:
-            print('Could not find a valid editor')
-        else:
-            print(f"Could not find the editor {editor}")
-        sys.exit(1)
+    editor_path: str = _get_editor_path(editor)
 
     subprocess.call([editor_path, config])
 
 
-def _get_editor_path(editor: typing.Optional[str]) -> typing.Optional[str]:
+def _get_editor_path(editor: typing.Optional[str]) -> str:
     if editor is not None:
-        return spawn.find_executable(editor)
+        path = spawn.find_executable(editor)
+        if path is None:
+            raise click.ClickException(f"Could not find the editor {editor}")
+        return path
 
     for default_editor in DEFAULT_EDITORS:
         path = spawn.find_executable(default_editor)
         if path is not None:
             return path
 
-    return None
+    raise click.ClickException('Could not find a valid editor')

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -26,7 +26,7 @@ import webbrowser
 import click
 
 from kitovu import utils
-from kitovu.sync import syncing
+from kitovu.sync import syncing, settings
 from kitovu.gui import app as guiapp
 
 
@@ -94,6 +94,8 @@ def edit(config: typing.Optional[pathlib.Path] = None, editor: typing.Optional[s
         editor = os.environ['EDITOR']
     editor_path: str = _get_editor_path(editor)
 
+    if config is None:
+        config = settings.get_config_file_path()
     subprocess.call([editor_path, config])
 
 

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -22,6 +22,7 @@ import platform
 from distutils import spawn
 import subprocess
 import os
+import webbrowser
 
 import click
 
@@ -66,6 +67,13 @@ def validate(config: typing.Optional[pathlib.Path] = None) -> None:
         syncing.validate_config(config, CliReporter())
     except utils.UsageError as ex:
         raise click.ClickException(str(ex))
+
+
+@cli.command()
+def docs() -> None:
+    """Open the documentation in the browser."""
+    # FIXME: make version aware
+    webbrowser.open_new_tab('https://kitovu.readthedocs.io/en/latest')
 
 
 AVAILABLE_EDITORS = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,11 @@ def reporter():
     return cli.CliReporter()
 
 
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
 def test_reporter(capsys, reporter):
     reporter.warn("my test")
     reporter.warn("another test")
@@ -20,11 +25,16 @@ def test_reporter(capsys, reporter):
     assert captured.err == "my test\nanother test\n"
 
 
-class TestEdit:
+def test_docs(runner, monkeypatch):
+    calls = []
+    monkeypatch.setattr('webbrowser.open', lambda *args: calls.append(args))
 
-    @pytest.fixture
-    def runner(self):
-        return CliRunner()
+    runner.invoke(cli.docs)
+
+    assert calls == [('https://kitovu.readthedocs.io/en/latest', 2)]
+
+
+class TestEdit:
 
     @pytest.fixture(autouse=True)
     def clear_env(self, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,13 +25,12 @@ def test_reporter(capsys, reporter):
     assert captured.err == "my test\nanother test\n"
 
 
-def test_docs(runner, monkeypatch):
-    calls = []
-    monkeypatch.setattr('webbrowser.open', lambda *args: calls.append(args))
+def test_docs(runner, mocker):
+    mock = mocker.patch('webbrowser.open_new_tab', autospec=True)
 
     runner.invoke(cli.docs)
 
-    assert calls == [('https://kitovu.readthedocs.io/en/latest', 2)]
+    mock.assert_called_once_with('https://kitovu.readthedocs.io/en/latest')
 
 
 class TestEdit:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,14 @@
 import pytest
+import pathlib
 
-from kitovu.cli import CliReporter
+from click.testing import CliRunner
+
+from kitovu import cli
 
 
 @pytest.fixture
 def reporter():
-    return CliReporter()
+    return cli.CliReporter()
 
 
 def test_reporter(capsys, reporter):
@@ -15,3 +18,97 @@ def test_reporter(capsys, reporter):
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == "my test\nanother test\n"
+
+
+class TestEdit:
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture(autouse=True)
+    def clear_env(self, monkeypatch):
+        monkeypatch.delenv('EDITOR', raising=False)
+
+    class TestMissing:
+
+        @pytest.fixture(autouse=True)
+        def patch(self, monkeypatch):
+            self.checked_editors = []
+            monkeypatch.setattr('distutils.spawn.find_executable', self._find_executable_patch)
+
+        def test_defaults(self, runner):
+            result = runner.invoke(cli.edit)
+
+            assert result.exit_code == 1
+
+            assert self.checked_editors == ['vim', 'emacs', 'nano', 'editor', 'notepad']
+            assert result.output == 'Could not find a valid editor\n'
+
+        def test_from_args(self, runner):
+            result = runner.invoke(cli.edit, ['--editor', 'myeditor'])
+
+            assert result.exit_code == 1
+
+            assert self.checked_editors == ['myeditor']
+            assert result.output == 'Could not find the editor myeditor\n'
+
+        def test_from_env(self, runner, monkeypatch):
+            monkeypatch.setenv('EDITOR', 'editor_from_env')
+
+            result = runner.invoke(cli.edit)
+
+            assert result.exit_code == 1
+
+            assert self.checked_editors == ['editor_from_env']
+            assert result.output == 'Could not find the editor editor_from_env\n'
+
+        def _find_executable_patch(self, editor):
+            self.checked_editors.append(editor)
+            return None
+
+    class TestAvailable:
+
+        @pytest.fixture(autouse=True)
+        def patch(self, monkeypatch):
+            self.checked_editors = []
+            monkeypatch.setattr('distutils.spawn.find_executable', self._find_executable_patch)
+
+            self.subprocess_calls = []
+            monkeypatch.setattr('subprocess.call', lambda args: self.subprocess_calls.append(args))
+
+        def test_with_an_available_editor(self, runner, monkeypatch):
+            result = runner.invoke(cli.edit, ['--config', 'test.yml'])
+
+            assert result.exception is None
+            assert result.exit_code == 0
+
+            assert self.checked_editors == ['vim']
+            assert result.output == ''
+            assert self.subprocess_calls == [['/some/example/path/vim', pathlib.Path('test.yml')]]
+
+        def test_with_an_available_editor_from_the_args(self, runner, monkeypatch):
+            result = runner.invoke(cli.edit, ['--editor', 'myeditor', '--config', 'test.yml'])
+
+            assert result.exception is None
+            assert result.exit_code == 0
+
+            assert self.checked_editors == ['myeditor']
+            assert result.output == ''
+            assert self.subprocess_calls == [['/some/example/path/myeditor', pathlib.Path('test.yml')]]
+
+        def test_with_an_available_editor_from_the_env(self, runner, monkeypatch):
+            monkeypatch.setenv('EDITOR', 'editor_from_env')
+
+            result = runner.invoke(cli.edit, ['--config', 'test.yml'])
+
+            assert result.exception is None
+            assert result.exit_code == 0
+
+            assert self.checked_editors == ['editor_from_env']
+            assert result.output == ''
+            assert self.subprocess_calls == [['/some/example/path/editor_from_env', pathlib.Path('test.yml')]]
+
+        def _find_executable_patch(self, editor):
+            self.checked_editors.append(editor)
+            return f'/some/example/path/{editor}'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,7 +52,7 @@ class TestEdit:
             assert result.exit_code == 1
 
             assert self.checked_editors == ['vim', 'emacs', 'nano', 'editor', 'notepad']
-            assert result.output == 'Could not find a valid editor\n'
+            assert result.output == 'Error: Could not find a valid editor\n'
 
         def test_from_args(self, runner):
             result = runner.invoke(cli.edit, ['--editor', 'myeditor'])
@@ -60,7 +60,7 @@ class TestEdit:
             assert result.exit_code == 1
 
             assert self.checked_editors == ['myeditor']
-            assert result.output == 'Could not find the editor myeditor\n'
+            assert result.output == 'Error: Could not find the editor myeditor\n'
 
         def test_from_env(self, runner, monkeypatch):
             monkeypatch.setenv('EDITOR', 'editor_from_env')
@@ -70,7 +70,7 @@ class TestEdit:
             assert result.exit_code == 1
 
             assert self.checked_editors == ['editor_from_env']
-            assert result.output == 'Could not find the editor editor_from_env\n'
+            assert result.output == 'Error: Could not find the editor editor_from_env\n'
 
         def _find_executable_patch(self, editor):
             self.checked_editors.append(editor)


### PR DESCRIPTION
Issues:
* [x] Make `kitovu docs` version aware.
 * How could we make different versions in readthedocs?
* [x] Get the default filename in `kitovu edit`
 * Currently it is built in the `settings.py`
 * Option 1: import `settings.py` in the `cli.py` => circular dependencies
 * Option 2: Move the default filename method to `utils.py` and still set it in `settings.py` for most commands
 * Option 3: Move the default filename method to `utils.py` and always pass the filename to the `syncing.py`. Advantage: less optional args; Disadvantage: more logic in the cli

@The-Compiler, @bytinbit  what are your opinions?