### PR TITLE
Only import GUI if necessary

### DIFF
--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -23,7 +23,6 @@ import click
 
 from kitovu import utils
 from kitovu.sync import syncing
-from kitovu.gui import app as guiapp
 
 
 class CliReporter(utils.AbstractReporter):
@@ -41,6 +40,7 @@ def cli() -> None:
 @cli.command()
 def gui() -> None:
     """Start the kitovu GUI."""
+    from kitovu.gui import app as guiapp
     sys.exit(guiapp.run())
 
 


### PR DESCRIPTION
Otherwise, PyQt5 is required to run the CLI.