### PR TITLE
pylint: Disable messages about disabled messages

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,9 @@ disable=
     global-statement,
     too-few-public-methods,
     no-self-use,
-    missing-docstring
+    missing-docstring,
+    locally-disabled,
+    suppressed-message
 
 [reports]
 format=colorized


### PR DESCRIPTION
When disabling a message, pylint shows:

I: 14, 0: Locally disabling no-value-for-parameter (E1120) (locally-disabled)
I: 15, 0: Suppressed 'no-value-for-parameter' (from line 14) (suppressed-message)

We don't need those, so let's turn them off.