### PR TITLE
Use temppath instead of tmpdir across the codebase

### DIFF
--- a/tests/gui/test_confscreen.py
+++ b/tests/gui/test_confscreen.py
@@ -6,8 +6,8 @@ from kitovu.gui import confscreen
 
 
 @pytest.fixture(autouse=True)
-def kitovu_yaml(monkeypatch, tmpdir):
-    config = tmpdir / 'kitovu.yaml'
+def kitovu_yaml(monkeypatch, temppath):
+    config = temppath / 'kitovu.yaml'
     config.write_text('root-dir: ~/hsr', encoding='utf-8')
     monkeypatch.setattr(confscreen.settings, 'get_config_file_path',
                         lambda: pathlib.Path(config))

--- a/tests/gui/test_syncscreen.py
+++ b/tests/gui/test_syncscreen.py
@@ -1,4 +1,5 @@
-import py.path
+import pathlib
+
 import pytest
 from PyQt5.QtCore import QProcess
 
@@ -7,19 +8,19 @@ from kitovu.gui import syncscreen
 
 class ProcessPatcher:
 
-    def __init__(self, monkeypatch, tmpdir):
+    def __init__(self, monkeypatch, temppath: pathlib.Path):
         self._monkeypatch = monkeypatch
-        self._tmpdir = tmpdir
+        self._temppath = temppath
 
     def patch(self, *code):
-        script: py.path.local = self._tmpdir / 'script.py'
+        script: pathlib.Path = self._temppath / 'script.py'
         script.write_text('\n'.join(code), encoding='utf-8')
         self._monkeypatch.setattr(syncscreen.SyncScreen, 'PYTHON_ARGS', [str(script)])
 
 
 @pytest.fixture
-def patcher(monkeypatch, tmpdir):
-    return ProcessPatcher(monkeypatch=monkeypatch, tmpdir=tmpdir)
+def patcher(monkeypatch, temppath):
+    return ProcessPatcher(monkeypatch=monkeypatch, temppath=temppath)
 
 
 @pytest.fixture

--- a/tests/sync/test_smb.py
+++ b/tests/sync/test_smb.py
@@ -1,7 +1,6 @@
 import pathlib
 
 import pytest
-import py.path
 import attr
 import keyring
 from smb.SMBConnection import SMBConnection
@@ -173,8 +172,8 @@ class TestWithConnectedPlugin:
 
 class TestValidations:
 
-    def test_configuration_with_the_minimum_required_fields(self, mocker, tmpdir: py.path.local):
-        config_yml = tmpdir / 'config.yml'
+    def test_configuration_with_the_minimum_required_fields(self, mocker, temppath: pathlib.Path):
+        config_yml = temppath / 'config.yml'
         config_yml.write_text("""
         root-dir: ./asdf
         connections:
@@ -190,8 +189,8 @@ class TestValidations:
 
         syncing.validate_config(config_yml, reporter.TestReporter())
 
-    def test_configuration_with_the_all_available_fields(self, mocker, tmpdir: py.path.local):
-        config_yml = tmpdir / 'config.yml'
+    def test_configuration_with_the_all_available_fields(self, mocker, temppath: pathlib.Path):
+        config_yml = temppath / 'config.yml'
         config_yml.write_text("""
         root-dir: ./asdf
         connections:
@@ -214,8 +213,8 @@ class TestValidations:
 
         syncing.validate_config(config_yml, reporter.TestReporter())
 
-    def test_configuration_with_unexpected_fields(self, mocker, tmpdir: py.path.local):
-        config_yml = tmpdir / 'config.yml'
+    def test_configuration_with_unexpected_fields(self, mocker, temppath: pathlib.Path):
+        config_yml = temppath / 'config.yml'
         config_yml.write_text("""
         root-dir: ./asdf
         connections:

--- a/tests/test_dummyplugin.py
+++ b/tests/test_dummyplugin.py
@@ -1,8 +1,6 @@
 import pathlib
 import typing
 
-import py.path
-
 
 def test_connection_active(plugin) -> None:
     plugin.connect()
@@ -53,8 +51,8 @@ def test_if_list_path_lists_correct_pathnames(plugin):
     assert all_paths == pathnames
 
 
-def test_if_correct_file_retrieved(plugin, tmpdir: py.path.local):
-    sample = tmpdir / 'testsample.txt'
+def test_if_correct_file_retrieved(plugin, temppath: pathlib.Path):
+    sample = temppath / 'testsample.txt'
 
     plugin.connect()
     with sample.open("wb") as f:
@@ -64,8 +62,8 @@ def test_if_correct_file_retrieved(plugin, tmpdir: py.path.local):
     assert text == str(pathlib.PurePath("remote_dir/test/example1.txt")) + "\n1"
 
 
-def test_if_changed_digest_still_retrieves_correct_file(plugin, tmpdir: py.path.local):
-    sample = tmpdir / 'testsample.txt'
+def test_if_changed_digest_still_retrieves_correct_file(plugin, temppath: pathlib.Path):
+    sample = temppath / 'testsample.txt'
 
     plugin.connect()
     plugin.remote_digests[pathlib.PurePath("remote_dir/test/example1.txt")] = "42"  # change remote digest


### PR DESCRIPTION
We have a temppath fixture returning a pathlib.Path for pytest's tmpdir because
we need pathlib objects at some points. For consistency (and so we don't have to
care about two slightly different APIs), just let's use temppath everywhere.

No JIRA issue because this took ~5min.