### PR TITLE
Display proper URL for moodle password prompt

### DIFF
--- a/src/kitovu/sync/plugin/moodle.py
+++ b/src/kitovu/sync/plugin/moodle.py
@@ -61,8 +61,7 @@ class MoodlePlugin(syncplugin.AbstractSyncPlugin):
         if not self._url.endswith('/'):
             self._url += '/'
 
-        prompt = ("Enter token from https://moodle.hsr.ch/user/preferences.php -> "
-                  "Sicherheitsschlüssel")
+        prompt = f"Enter token from {self._url}user/preferences.php -> Sicherheitsschlüssel"
         self._token = utils.get_password('moodle', self._url, prompt)
 
     def connect(self) -> None:


### PR DESCRIPTION
Quick follow-up on better password prompts - we should display the configured URL here.