### PR TITLE
always load the config file in when the config edit window is opened

### DIFF
--- a/src/kitovu/gui/confscreen.py
+++ b/src/kitovu/gui/confscreen.py
@@ -23,10 +23,6 @@ class ConfScreen(QWidget):
         self._vbox.addWidget(self._edit)
 
         self._conf_file: pathlib.Path = settings.get_config_file_path()
-        try:
-            self._edit.setPlainText(self._conf_file.read_text('utf-8'))
-        except FileNotFoundError:
-            pass
 
         self._buttons = QDialogButtonBox()
         self._cancel_button: QPushButton = self._buttons.addButton(
@@ -40,6 +36,12 @@ class ConfScreen(QWidget):
         self._cancel_button.clicked.connect(self.close_requested)
         self._save_button.clicked.connect(functools.partial(self.save, close=False))
         self._back_button.clicked.connect(functools.partial(self.save, close=True))
+
+    def load_file(self):
+        try:
+            self._edit.setPlainText(self._conf_file.read_text('utf-8'))
+        except FileNotFoundError:
+            pass
 
     def save(self, close: bool) -> None:
         text: str = self._edit.toPlainText()

--- a/src/kitovu/gui/confscreen.py
+++ b/src/kitovu/gui/confscreen.py
@@ -37,7 +37,7 @@ class ConfScreen(QWidget):
         self._save_button.clicked.connect(functools.partial(self.save, close=False))
         self._back_button.clicked.connect(functools.partial(self.save, close=True))
 
-    def load_file(self):
+    def load_file(self) -> None:
         try:
             self._edit.setPlainText(self._conf_file.read_text('utf-8'))
         except FileNotFoundError:

--- a/src/kitovu/gui/mainwindow.py
+++ b/src/kitovu/gui/mainwindow.py
@@ -21,7 +21,7 @@ class CentralWidget(QStackedWidget):
         self.addWidget(self._start_screen)
 
         self._start_screen.sync_pressed.connect(self.on_sync_pressed)
-        self._start_screen.conf_pressed.connect(self.open_conf_screen)
+        self._start_screen.conf_pressed.connect(self.on_conf_pressed)
 
         self._conf_screen.close_requested.connect(
             lambda: self.setCurrentWidget(self._start_screen))
@@ -38,7 +38,7 @@ class CentralWidget(QStackedWidget):
         self._sync_screen.start_sync()
 
     @pyqtSlot()
-    def open_conf_screen(self) -> None:
+    def on_conf_pressed(self) -> None:
         self._conf_screen.load_file()
         self.setCurrentWidget(self._conf_screen)
 

--- a/src/kitovu/gui/mainwindow.py
+++ b/src/kitovu/gui/mainwindow.py
@@ -21,8 +21,7 @@ class CentralWidget(QStackedWidget):
         self.addWidget(self._start_screen)
 
         self._start_screen.sync_pressed.connect(self.on_sync_pressed)
-        self._start_screen.conf_pressed.connect(
-            lambda: self.setCurrentWidget(self._conf_screen))
+        self._start_screen.conf_pressed.connect(self.open_conf_screen)
 
         self._conf_screen.close_requested.connect(
             lambda: self.setCurrentWidget(self._start_screen))
@@ -37,6 +36,11 @@ class CentralWidget(QStackedWidget):
     def on_sync_pressed(self) -> None:
         self.setCurrentWidget(self._sync_screen)
         self._sync_screen.start_sync()
+
+    @pyqtSlot()
+    def open_conf_screen(self) -> None:
+        self._conf_screen.load_file()
+        self.setCurrentWidget(self._conf_screen)
 
 
 class MainWindow(QMainWindow):

--- a/tests/gui/test_confscreen.py
+++ b/tests/gui/test_confscreen.py
@@ -24,6 +24,7 @@ def kitovu_yaml(monkeypatch, temppath):
 @pytest.fixture
 def screen(qtbot):
     cs = confscreen.ConfScreen()
+    cs.load_file()
     qtbot.add_widget(cs)
     return cs
 


### PR DESCRIPTION
Before it kept the edited configuration and when you press "Abbrechen" and return to the config file it's still updated.

Hopefully I didn't break Qt conventions ;)