### PR TITLE
Gui import check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'jsonschema',
     ],
     extras_require={
-        'gui': ['PyQt5']
+        'gui': ['PyQt5'],
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         'jsonschema',
     ],
     extras_require={
+        'gui': ['PyQt5']
         # eg:
         #   'rst': ['docutils>=0.11'],
         #   ':python_version=="2.6"': ['argparse'],

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,6 @@ setup(
     ],
     extras_require={
         'gui': ['PyQt5']
-        # eg:
-        #   'rst': ['docutils>=0.11'],
-        #   ':python_version=="2.6"': ['argparse'],
     },
     entry_points={
         'console_scripts': [

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -44,8 +44,15 @@ def cli(loglevel: str) -> None:
 @cli.command()
 def gui() -> None:
     """Start the kitovu GUI."""
-    from kitovu.gui import app as guiapp
-    sys.exit(guiapp.run())
+    try:
+        from kitovu.gui import app as guiapp
+        sys.exit(guiapp.run())
+    except ModuleNotFoundError as e:
+        if e.name == 'PyQt5':
+            print('To run the GUI, you need to install the extra GUI dependencies')
+            print('Run "pip install kitovu[gui]"')
+        else:
+            raise
 
 
 @cli.command()
@@ -85,8 +92,8 @@ def docs() -> None:
 @cli.command()
 @click.option('--config', type=pathlib.Path, help="The configuration file to edit")
 @click.option('--editor', type=str, help="The command of the editor to use. "
-              f"Default: $EDITOR or the first existing out of "
-              f"{settings.EditorSpawner.DEFAULT_EDITORS_STR}")
+                                         f"Default: $EDITOR or the first existing out of "
+                                         f"{settings.EditorSpawner.DEFAULT_EDITORS_STR}")
 def edit(config: typing.Optional[pathlib.Path] = None, editor: typing.Optional[str] = None) -> None:
     """Edit the configuration file."""
     spawner = settings.EditorSpawner()

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -49,8 +49,8 @@ def gui() -> None:
         sys.exit(guiapp.run())
     except ModuleNotFoundError as e:
         if e.name == 'PyQt5':
-            print('To run the GUI, you need to install the extra GUI dependencies')
-            print('Run "pip install kitovu[gui]"')
+            print('To run the GUI, you need to install the extra GUI dependencies', file=sys.stderr)
+            print('Run "pip install kitovu[gui]"', file=sys.stderr)
         else:
             raise
 

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -47,8 +47,8 @@ def gui() -> None:
     try:
         from kitovu.gui import app as guiapp
         sys.exit(guiapp.run())
-    except ModuleNotFoundError as e:
-        if e.name == 'PyQt5':
+    except ModuleNotFoundError as ex:
+        if ex.name == 'PyQt5':
             print('To run the GUI, you need to install the extra GUI dependencies', file=sys.stderr)
             print('To do so, run: pip install "kitovu[gui]"', file=sys.stderr)
             sys.exit(1)

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -51,6 +51,7 @@ def gui() -> None:
         if e.name == 'PyQt5':
             print('To run the GUI, you need to install the extra GUI dependencies', file=sys.stderr)
             print('To do so, run: pip install "kitovu[gui]"', file=sys.stderr)
+            sys.exit(1)
         else:
             raise
 

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -92,8 +92,8 @@ def docs() -> None:
 @cli.command()
 @click.option('--config', type=pathlib.Path, help="The configuration file to edit")
 @click.option('--editor', type=str, help="The command of the editor to use. "
-                                         f"Default: $EDITOR or the first existing out of "
-                                         f"{settings.EditorSpawner.DEFAULT_EDITORS_STR}")
+              f"Default: $EDITOR or the first existing out of "
+              f"{settings.EditorSpawner.DEFAULT_EDITORS_STR}")
 def edit(config: typing.Optional[pathlib.Path] = None, editor: typing.Optional[str] = None) -> None:
     """Edit the configuration file."""
     spawner = settings.EditorSpawner()

--- a/src/kitovu/cli.py
+++ b/src/kitovu/cli.py
@@ -50,7 +50,7 @@ def gui() -> None:
     except ModuleNotFoundError as e:
         if e.name == 'PyQt5':
             print('To run the GUI, you need to install the extra GUI dependencies', file=sys.stderr)
-            print('Run "pip install kitovu[gui]"', file=sys.stderr)
+            print('To do so, run: pip install "kitovu[gui]"', file=sys.stderr)
         else:
             raise
 


### PR DESCRIPTION
This fixes #70.

I'm not sure if the style of the user message is good, and if the code should be somewhere else, but I'm quite content the way it is.

I haven't written any tests of it, since I don't know how you would go about faking having/not having this module installed.

One small problem: at least in my shell (zsh) I had to escape the `[` and `]` to get it to install properly, don't know if we should warn users of this. On the other hand, it should be clear that the message comes from zsh and not the package.

I've just tested with `pip install .[gui]` (no space behind that dot), and that worked.