### PR TITLE
switch from deprecated yaml.load without a specific loader to a helper method

### DIFF
--- a/src/kitovu/sync/settings.py
+++ b/src/kitovu/sync/settings.py
@@ -128,7 +128,7 @@ class Settings:
         validator = utils.SchemaValidator()
 
         try:
-            data = yaml.full_load(stream)
+            data = yaml.load(stream, Loader=yaml.FullLoader)
         except (yaml.YAMLError, OSError, UnicodeDecodeError) as error:
             raise utils.UsageError(f"Failed to load configuration:\n{error}")
 

--- a/src/kitovu/sync/settings.py
+++ b/src/kitovu/sync/settings.py
@@ -128,7 +128,7 @@ class Settings:
         validator = utils.SchemaValidator()
 
         try:
-            data = yaml.load(stream)
+            data = yaml.full_load(stream)
         except (yaml.YAMLError, OSError, UnicodeDecodeError) as error:
             raise utils.UsageError(f"Failed to load configuration:\n{error}")
 

--- a/src/kitovu/sync/settings.py
+++ b/src/kitovu/sync/settings.py
@@ -128,7 +128,7 @@ class Settings:
         validator = utils.SchemaValidator()
 
         try:
-            data = yaml.load(stream, Loader=yaml.Loader)
+            data = yaml.load(stream, Loader=yaml.SafeLoader)
         except (yaml.YAMLError, OSError, UnicodeDecodeError) as error:
             raise utils.UsageError(f"Failed to load configuration:\n{error}")
 

--- a/src/kitovu/sync/settings.py
+++ b/src/kitovu/sync/settings.py
@@ -128,7 +128,7 @@ class Settings:
         validator = utils.SchemaValidator()
 
         try:
-            data = yaml.load(stream, Loader=yaml.FullLoader)
+            data = yaml.load(stream, Loader=yaml.Loader)
         except (yaml.YAMLError, OSError, UnicodeDecodeError) as error:
             raise utils.UsageError(f"Failed to load configuration:\n{error}")
 


### PR DESCRIPTION
Issue: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation